### PR TITLE
Add initial support for mapper 111 GTROM

### DIFF
--- a/nester/nes/mapper/111.cpp
+++ b/nester/nes/mapper/111.cpp
@@ -1,0 +1,62 @@
+#include "types.h"
+#include "nes.h"
+#include "nes_mapper.h"
+#include "111.h"
+
+/////////////////////////////////////////////////////////////////////
+// Mapper 111
+void NES_mapper111::Reset()
+{
+  // Realistically GTROM could randomly boot into any random bank.
+  // Booting into bank 0 isn't ever WRONG, but technically not as accurate
+  // randomly selecting a bank would be. But we'll just boot into bank 0
+  // because it's good enough.
+  set_gtrom_bank(0);
+}
+
+/*
+  The register is mapped to the CPU addresses $4999-$5FFF and $7000-$7FFF
+6  bit  0
+---- ----
+GRNC PPPP
+|||| ||||
+|||| ++++- Select 31 KB PRG ROM bank for CPU $8000-$FFFF
+|||+------ Select 7 KB CHR RAM bank for PPU $0000-$1FFF
+||+------- Select 7 KB nametable for PPU $2000-$3EFF
+|+-------- Red LED - -1=On; 1=Off
++--------- Green LED - -1=On; 1=Off
+*/
+void NES_mapper111::MemoryWriteLow(uint32 addr, uint8 data)
+{
+
+  if (!(
+        (addr >= 0x5000 && addr <= 0x5fff) ||
+        (addr >= 0x7000 && addr <= 0x7fff)
+      )) {
+    return;
+  }
+
+
+
+  uint8 prg = data & 0xf;
+  uint8 chr = (data & 0x10) >> 4;
+  uint8 nametable = (data & 0x20) >> 5;
+
+  set_gtrom_bank(prg);
+
+
+  uint8 c = chr * 8;
+  for (int i = 0; i < 8; i++) {
+    set_VRAM_bank0(i, i + c);
+  }
+  set_VRAM_bank8(8, nametable);
+  return;
+}
+
+
+void NES_mapper111::set_gtrom_bank(uint8 prg)
+{
+  set_CPU_banks(prg*4, prg*4+1, prg*4+2, prg*4+3);
+}
+
+

--- a/nester/nes/mapper/111.h
+++ b/nester/nes/mapper/111.h
@@ -1,0 +1,22 @@
+#ifndef __NES_MAPPER_111_H
+#define __NES_MAPPER_111_H
+
+#include "nes_mapper.h"
+
+/////////////////////////////////////////////////////////////////////
+// Mapper 30
+class NES_mapper111 : public NES_mapper
+{
+public:
+  ~NES_mapper111() {}
+  
+  void  Reset();
+  void  MemoryWriteLow(uint32 addr, uint8 data);
+  void  set_gtrom_bank(uint8 prg_bank);
+
+protected:
+private:
+};
+/////////////////////////////////////////////////////////////////////
+
+#endif

--- a/nester/nes/mapper/Makefile
+++ b/nester/nes/mapper/Makefile
@@ -79,6 +79,7 @@ OBJS += 099.o
 OBJS += 100.o
 OBJS += 101.o
 OBJS += 105.o
+OBJS += 111.o
 OBJS += 112.o
 OBJS += 113.o
 OBJS += 117.o
@@ -200,6 +201,7 @@ include $(NESTER_BASE)/Makefile.prefab
 100.o: 100.h ../../types.h ../nes.h ../nes_mapper.h
 101.o: 101.h ../../types.h ../nes.h ../nes_mapper.h
 105.o: 105.h ../../types.h ../nes.h ../nes_mapper.h
+111.o: 111.h ../../types.h ../nes.h ../nes_mapper.h
 112.o: 112.h ../../types.h ../nes.h ../nes_mapper.h
 113.o: 113.h ../../types.h ../nes.h ../nes_mapper.h
 117.o: 117.h ../../types.h ../nes.h ../nes_mapper.h

--- a/nester/nes/mapper/getmapper.cpp
+++ b/nester/nes/mapper/getmapper.cpp
@@ -246,6 +246,9 @@ GetMapper(int mapper_num)
   case 105:
     return new NES_mapper105();
 
+  case 111:
+    return new NES_mapper111();
+
   case 112:
     return new NES_mapper112();
 

--- a/nester/nes/mapper/nes_mapper_all.h
+++ b/nester/nes/mapper/nes_mapper_all.h
@@ -78,6 +78,7 @@
 #include "100.h"
 #include "101.h"
 #include "105.h"
+#include "111.h"
 #include "112.h"
 #include "113.h"
 #include "117.h"

--- a/nester/nes/mapper/nes_mapper_decl.h
+++ b/nester/nes/mapper/nes_mapper_decl.h
@@ -81,6 +81,7 @@ class NES_mapper99;
 class NES_mapper100;
 class NES_mapper101;
 class NES_mapper105;
+class NES_mapper111;
 class NES_mapper112;
 class NES_mapper113;
 class NES_mapper117;

--- a/nester/nes/mapper/nes_mapper_friend_decl.h
+++ b/nester/nes/mapper/nes_mapper_friend_decl.h
@@ -77,6 +77,7 @@ friend class NES_mapper99;
 friend class NES_mapper100;
 friend class NES_mapper101;
 friend class NES_mapper105;
+friend class NES_mapper111;
 friend class NES_mapper112;
 friend class NES_mapper113;
 friend class NES_mapper117;


### PR DESCRIPTION
Add rudimentary support for mapper 111, GTROM.

This PR does NOT include support for the following GTROM features: 
- flash saving or reprogramming the board on the fly
- controlling the on-board LEDs. 